### PR TITLE
Checks duplicate entries router and navbar

### DIFF
--- a/generators/crud/index.js
+++ b/generators/crud/index.js
@@ -128,6 +128,12 @@ module.exports = class extends Generator {
     }
 
     modifyDestFile("src/router.js", (routerJs) => {
+
+      //check router.js content to avoid duplicate entries
+      if(utils.wordInText(templateData.serviceNamePascalCase, routerJs)){
+        return;
+      }
+
       let imports = this.fs.read(this.templatePath("imports_router.ejs"));
       let jsonRoute = this.fs.read(this.templatePath("json_route_router.ejs"));
 
@@ -147,6 +153,12 @@ module.exports = class extends Generator {
     });
 
     modifyDestFile("src/components/Navbar.vue", navbar => {
+
+      //check navbar content to avoid duplicate entries
+      if(utils.wordInText(templateData.serviceNamePascalCase, navbar)){
+        return;
+      }
+      
       let addMenuNavBar = this.fs.read(
         this.templatePath("add_menu_navbar.ejs")
       );

--- a/generators/crud/index.js
+++ b/generators/crud/index.js
@@ -155,7 +155,7 @@ module.exports = class extends Generator {
     modifyDestFile("src/components/Navbar.vue", navbar => {
 
       //check navbar content to avoid duplicate entries
-      if(utils.wordInText(templateData.serviceNamePascalCase, navbar)){
+      if(utils.wordInText(templateData.serviceNameTitleCase, navbar)){
         return;
       }
       

--- a/generators/utils.js
+++ b/generators/utils.js
@@ -8,5 +8,11 @@ const insertAfter = function(txt, search, insert) {
   return [txt.slice(0, position), insert, txt.slice(position)].join('');
 };
 
+const wordInText = function(search, txt) {
+  const regexWord = new RegExp(`\\b${search}\\b`);
+  return regexWord.test(txt);
+}
+
 module.exports.insertBefore = insertBefore;
 module.exports.insertAfter = insertAfter;
+module.exports.wordInText = wordInText;


### PR DESCRIPTION
Add checks to avoid duplicate entries on Navbar.vue and router.js based on the serviceName. 
- The serviceNameTitleCase is checked on file Navbar.vue
- The serviceNamePascalCase is checked on file router.js
 

This pull request solves issue #12 