### PR TITLE
Prompt metajson path

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Therefore, the crud sub-generator requires the following information:
 
 It is worth mentioning that code customization can be achieved through config files related to each service endpoint. These files, called internally as **meta json**, contain configurations that modify how code is generated, such as what fields are available to edit or how data is displayed based on the data type. 
 
-Each meta json config file has to be named as _serviceName_.meta.json and located in the same directory where the sub-generator is executed; this way, the sub-generator will recognize them and apply the changes. 
+The configuration file is optional. If a path is not provided, the sub-generator will search for a file named as _serviceName_.meta.json.
 
 The list of available options for customization are:
 

--- a/generators/crud/index.js
+++ b/generators/crud/index.js
@@ -52,6 +52,12 @@ module.exports = class extends Generator {
         message:
           "Ingrese el nombre del servicio (basado en el mismo se generaran los nombres de las vistas)",
         default: "user"
+      },
+      {
+        type: "input",
+        name: "metaJsonPath",
+        message:
+          "Ingrese la ubicación del archivo de configuración (ej. generator/user.meta.json)"
       }
     ];
 
@@ -77,12 +83,14 @@ module.exports = class extends Generator {
     }
     let meta;
 
-    if (fs.existsSync(`${this.props.serviceName}.meta.json`))
-      meta = require(path.join(
-        process.cwd(),
-        `${this.props.serviceName}.meta.json`
-      ));
-
+    if (fs.existsSync(this.props.metaJsonPath)){
+      if(path.isAbsolute(this.props.metaJsonPath)){
+        meta = require(this.props.metaJsonPath);
+      }else{
+        meta = require(path.join(process.cwd(),this.props.metaJsonPath));
+      }
+    }
+      
     let thekeys;
 
     if (this.props.isPaginated) {

--- a/generators/crud/index.js
+++ b/generators/crud/index.js
@@ -57,7 +57,7 @@ module.exports = class extends Generator {
         type: "input",
         name: "metaJsonPath",
         message:
-          "Ingrese la ubicación del archivo de configuración (ej. generator/user.meta.json)"
+          "Ingrese la ubicación del archivo de configuración opcional (ej. generator/user.meta.json)"
       }
     ];
 
@@ -81,8 +81,11 @@ module.exports = class extends Generator {
         json: true
       });
     }
-    let meta;
 
+    let meta;
+    if(!this.props.metaJsonPath){
+      this.props.metaJsonPath = `${this.props.serviceName}.meta.json`;
+    }
     if (fs.existsSync(this.props.metaJsonPath)){
       if(path.isAbsolute(this.props.metaJsonPath)){
         meta = require(this.props.metaJsonPath);


### PR DESCRIPTION
Add another step in the crud sub-generator to ask for the path of the meta json config file. If it is not provided, the generator search for a file named  [serviceName].meta.json

Issue #10 