### PR TITLE
Upgrade DateField to support DateTime inputs 

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ The list of available options for customization are:
 - **no_edit**(*array*):  list of attribute names that determined if a field, related to an attribute name, is included or not in create/update forms.
 - **search**(*array*): list of attribute names used to generate search fields.
 - **currency_fields**(*array*):  list of attribute names that contain currency values. Used to generate Currency Fields and apply a Currency format.
-- **date_fields**(*array*): list of attribute names that contain date values. Used to generate Date Fields and apply a Date format. 
+- **date_fields**(*array*): list of attribute names that contain date values. Used to generate Date Fields and apply a Date format.
+- **datetime_fields**(*array*): list of attribute names that contain datetime values. Used to generate DateTime Fields and apply a DateTime format. 
 - **image_fields**(*array*): list of attribute names that contain image values. Used to generate Image Upload Fields.
 - **titles**(*dict*): dictionary used to customize the text of table headers and field labels. The key is an attribute name and the value es the custom text.
 - **max_length**(*dict*): dictionary used to set the max length of characters that a field can contain. The key is an attribute name and the value es the max length.

--- a/generators/crud/index.js
+++ b/generators/crud/index.js
@@ -204,7 +204,7 @@ module.exports = class extends Generator {
       }
 
       addPackage("vue-multiselect", "2.1.6");
-      addPackage("v-calendar", "^1.0.0-beta.16");
+      addPackage("v-calendar", "^2.3.0");
       addPackage("@fortawesome/fontawesome-svg-core", "^1.2.30");
       addPackage("@fortawesome/free-solid-svg-icons", "^5.14.0");
       addPackage("@fortawesome/vue-fontawesome", "^2.0.0");

--- a/generators/crud/templates/View.vue.ejs
+++ b/generators/crud/templates/View.vue.ejs
@@ -61,6 +61,8 @@ _%>
             <%_ } else { -%>
               <%_if(meta && meta.date_fields && meta.date_fields.includes(e)) {-%>
             td {{ row.<%= e %>  | dateFmt }}
+              <%_ } else if(meta && meta.datetime_fields && meta.datetime_fields.includes(e)) {-%>
+            td {{ row.<%= e %>  | dateTimeFmt }}
               <%_ } else { -%>
             td {{ row.<%= e %> }}
               <%_ } -%>
@@ -117,7 +119,9 @@ _%>
             <%_ } -%>
           <%_ } else { -%>
             <%_if(meta && meta.date_fields && meta.date_fields.includes(e)) {-%>
-            DateField(label='<%= fieldTitle %>' v-model='<%= collection %>Instance.<%=e%>'<%_lastParams(e, index)-%>)
+            DateField(label='<%= fieldTitle %>' mode="date" v-model='<%= collection %>Instance.<%=e%>'<%_lastParams(e, index)-%>)
+            <%_} else if(meta && meta.datetime_fields && meta.datetime_fields.includes(e)) {-%>
+            DateField(label='<%= fieldTitle %>' mode="dateTime" v-model='<%= collection %>Instance.<%=e%>'<%_lastParams(e, index)-%>)
             <%_} else if(meta && meta.image_fields && meta.image_fields.includes(e)) {-%>
             ImageUploadField(label='<%= fieldTitle %>' v-model='<%= collection %>Instance.<%=e%>'<%_lastParams(e, index)-%>)
             <%_ } else { -%>

--- a/generators/crud/templates/src/components/CrudBase.vue
+++ b/generators/crud/templates/src/components/CrudBase.vue
@@ -14,6 +14,11 @@ export default {
         return date.split('T')[0]
       return date
     },
+    dateTimeFmt(date) {
+      if (date)
+        return date.replace(/T/,' ');
+      return date
+    },
     currencyFmt(number) {
       if (number)
         return accounting.formatMoney(number, {

--- a/generators/crud/templates/src/components/DateField.vue
+++ b/generators/crud/templates/src/components/DateField.vue
@@ -2,9 +2,22 @@
   .field.column
     label.label {{ label }}
     .control
-      input.input(v-if='disabled' :value="value" :disabled="disabled")
-      v-date-picker(v-else locale="es" :value="value ? new Date(value) : null" @input="kore" :masks="{ L: 'YYYY-MM-DD' }")
-
+      input.input(v-if="disabled", :value="value", :disabled="disabled")
+      v-date-picker(
+        v-else,
+        :mode="mode",
+        :value="value",
+        @input="$emit('input', $event)",
+        :popover="popover",
+        :model-config="modelConfig",
+        :masks="masks"
+      )
+        template(v-slot="{ inputValue, inputEvents }")
+          input.input(
+            :value="inputValue",
+            v-on="inputEvents",
+            :disabled="disabled"
+          )
 </template>
 <script>
   import InputField from "../components/InputField";
@@ -15,14 +28,31 @@
     props: {
       type: {
         type: String,
-        default: 'date'
-      }
+        default: "date",
+      },
+      disabled: Boolean,
+      mode: String,
     },
     methods: {
-      kore: function ($event) {
-        let formatted = $event.toISOString().split('T')[0]
-        this.$emit('input', `${formatted}`)
-      }
-    }
-  }
+      focus() {},
+    },
+    computed: {
+      popover() {
+        return { visibility: this.disabled ? "hidden" : "hover-focus" };
+      },
+    },
+    data() {
+      return {
+        masks: {
+          input: "YYYY-MM-DD",
+          inputDateTime: "YYYY-MM-DD HH:MM",
+          inputDateTime24hr: "YYYY-MM-DD HH:MM",
+        },
+        modelConfig: {
+          type: "string",
+          mask: this.mode === "dateTime" ? "YYYY-MM-DDTHH:MM:SS" : "YYYY-MM-DD",
+        },
+      };
+    },
+  };
 </script>

--- a/generators/crud/templates/src/components/DateField.vue
+++ b/generators/crud/templates/src/components/DateField.vue
@@ -45,12 +45,12 @@
       return {
         masks: {
           input: "YYYY-MM-DD",
-          inputDateTime: "YYYY-MM-DD HH:MM",
-          inputDateTime24hr: "YYYY-MM-DD HH:MM",
+          inputDateTime: "YYYY-MM-DD HH:mm",
+          inputDateTime24hr: "YYYY-MM-DD HH:mm",
         },
         modelConfig: {
           type: "string",
-          mask: this.mode === "dateTime" ? "YYYY-MM-DDTHH:MM:SS" : "YYYY-MM-DD",
+          mask: this.mode === "dateTime" ? "YYYY-MM-DDTHH:mm:ss" : "YYYY-MM-DD",
         },
       };
     },


### PR DESCRIPTION
The changes included in this pull request are:
- v-calendar version was updated to 2.3.0.
- Several changes were introduced to the DateField component in order to unify logic for Date and DateTime inputs.
- Add another option in meta json files to config attributes that need to be handled as DateTime values.





